### PR TITLE
Update golang to 1.21.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/roadrunner-server/roadrunner/v2023
 
 go 1.21
 
-toolchain go1.21.0
+toolchain go1.21.1
 
 require (
 	github.com/buger/goterm v1.0.4


### PR DESCRIPTION
See https://go.googlesource.com/go/+/refs/tags/go1.21.1

# Reason for This PR

https://nvd.nist.gov/vuln/detail/CVE-2023-39320

## Description of Changes

Naively changes go.mod to toolchain 1.21.1

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
